### PR TITLE
Fixes for compatibility with more AIDBs:

### DIFF
--- a/cbm_defaults/archive_index_queries/disturbance_types.sql
+++ b/cbm_defaults/archive_index_queries/disturbance_types.sql
@@ -1,10 +1,9 @@
-SELECT tblDisturbanceTypeDefault.DistTypeID,
-tblDisturbanceTypeDefault.DistTypeName,
-tblDisturbanceTypeDefault.Description
-FROM tblDisturbanceTypeDefault LEFT JOIN (
-	SELECT tblDMAssociationDefault.DefaultDisturbanceTypeID
-	FROM tblDMAssociationDefault
-	GROUP BY tblDMAssociationDefault.DefaultDisturbanceTypeID) as dma
-	on tblDisturbanceTypeDefault.DistTypeID =
-	dma.DefaultDisturbanceTypeID
-WHERE dma.DefaultDisturbanceTypeID is not Null;
+SELECT DistTypeID, DistTypeName, Description
+FROM tbldisturbancetypedefault
+WHERE disttypeid IN (
+    SELECT DISTINCT defaultdisturbancetypeid
+    FROM tbldmassociationdefault
+) OR disttypeid IN (
+    SELECT DISTINCT defaultdisturbancetypeid
+    FROM tbldmassociationspudefault
+)

--- a/cbm_defaults/archive_index_queries/eco_boundary_dm_associations.sql
+++ b/cbm_defaults/archive_index_queries/eco_boundary_dm_associations.sql
@@ -1,15 +1,11 @@
 SELECT
-    tblDMAssociationDefault.DefaultDisturbanceTypeID,
-    tblSPUDefault.SPUID,
-    tblDMAssociationDefault.DMID
-FROM
-    tblDMAssociationDefault
-INNER JOIN tblSPUDefault ON
-    tblDMAssociationDefault.DefaultEcoBoundaryID = tblSPUDefault.EcoBoundaryID
-GROUP BY
-    tblDMAssociationDefault.DefaultDisturbanceTypeID,
-    tblSPUDefault.SPUID,
-    tblDMAssociationDefault.DMID,
-    tblDMAssociationDefault.DefaultDisturbanceTypeID
-HAVING
-    tblDMAssociationDefault.DefaultDisturbanceTypeID<>1;
+    DefaultDisturbanceTypeID,
+    SPUID,
+    DMID
+FROM tblDMAssociationDefault dma
+INNER JOIN tblSPUDefault spu
+    ON dma.DefaultEcoBoundaryID = spu.EcoBoundaryID
+WHERE DefaultDisturbanceTypeID NOT IN (
+    SELECT DISTINCT DefaultDisturbanceTypeID
+    FROM tblDMAssociationSPUDefault
+);

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="cbm_defaults",
-    version="2.1.0",
+    version="2.1.1",
     description="CBM-CFS3 archive-index database to sqlite utility",
     keywords=["cbm-cfs3"],
     long_description=long_description,


### PR DESCRIPTION
  - list of disturbance types returned by disturbance_types.sql now includes the disturbance types that exist in both tblDMAssociationDefault and tblDMAssociationSPUDefault
  - eco_boundary_dm_associations.sql now excludes all disturbance types already in tblDMAssociationSPUDefault, not just 1