### PR TITLE
Gcbm dm values support

### DIFF
--- a/cbm_defaults/archive_index_queries/disturbance_matrix.sql
+++ b/cbm_defaults/archive_index_queries/disturbance_matrix.sql
@@ -4,4 +4,3 @@ tblDMValuesLookup.DMRow,
 tblDMValuesLookup.DMColumn,
 tblDMValuesLookup.Proportion
 FROM tblDMValuesLookup
-WHERE tblDMValuesLookup.DMID=?;

--- a/cbm_defaults/cbm_defaults_builder.py
+++ b/cbm_defaults/cbm_defaults_builder.py
@@ -617,13 +617,24 @@ class CBMDefaultsBuilder:
                 "disturbance_matrix"
             )
         )
+
         dm_values = dm_values_processor.process_dm_values(
-            dm_value_rows, pool_cross_walk
+            [list(x) for x in dm_value_rows],
+            colnames=[str(x[0]) for x in dm_value_rows[0].cursor_description],
+            pool_cross_walk=pool_cross_walk
         )
-        dm_values.to_sql(
+
+        dm_values.rename(
+            columns={
+                "DMID": "disturbance_matrix_id",
+                "DMRow": "source_pool_id",
+                "DMColumn": "sink_pool_id",
+                "Proportion": "proportion",
+            }
+        ).to_sql(
             name="disturbance_matrix_value",
             con=self.connection,
-            if_exists="replace",
+            if_exists="append",
             index=False,
         )
 

--- a/cbm_defaults/cbm_defaults_builder.py
+++ b/cbm_defaults/cbm_defaults_builder.py
@@ -7,7 +7,8 @@ the CBM-CFS3 archive index database format.
 from cbm_defaults import cbm_defaults_database
 from cbm_defaults import local_csv_table
 from cbm_defaults import helper
-
+from cbm_defaults import dm_values_processor
+import pandas as pd
 logger = helper.get_logger()
 
 
@@ -596,7 +597,7 @@ class CBMDefaultsBuilder:
                 tr_id += 1
 
     def _populate_disturbance_matrix_values(self):
-        pool_cross_walk = {}
+        pool_cross_walk: dict[int, int] = {}
         for row in local_csv_table.read_csv_file("pool_cross_walk.csv"):
             pool_cross_walk[int(row["cbm3_pool_code"])] = int(
                 row["cbm3_5_pool_code"]
@@ -611,21 +612,20 @@ class CBMDefaultsBuilder:
                 self.connection, "disturbance_matrix", id=row.DMID
             )
 
-            for dm_value_row in self.archive_index.get_parameters(
-                "disturbance_matrix", params=(row.DMID,)
-            ):
-                src = pool_cross_walk[dm_value_row.DMRow]
-                sink = pool_cross_walk[dm_value_row.DMColumn]
-                if src == -1 or sink == -1:
-                    continue
-                cbm_defaults_database.add_record(
-                    self.connection,
-                    "disturbance_matrix_value",
-                    disturbance_matrix_id=row.DMID,
-                    source_pool_id=src,
-                    sink_pool_id=sink,
-                    proportion=dm_value_row.Proportion,
-                )
+        dm_value_rows = list(
+            self.archive_index.get_parameters(
+                "disturbance_matrix"
+            )
+        )
+        dm_values = dm_values_processor.process_dm_values(
+            dm_value_rows, pool_cross_walk
+        )
+        dm_values.to_sql(
+            name="disturbance_matrix_value",
+            con=self.connection,
+            if_exists="replace",
+            index=False,
+        )
 
         tr_id = 1
         for locale in self.locales:

--- a/cbm_defaults/dm_values_processor.py
+++ b/cbm_defaults/dm_values_processor.py
@@ -82,7 +82,7 @@ def process_dm_values(
         if key in off_diag_rowsums_dict:
             row_sum = off_diag_rowsums_dict[key]
             retention = 1.0 - row_sum
-            if np.isclose(abs(retention), 0.0, atol=1.e-6):
+            if np.isclose(abs(retention), 0.0, atol=1.e-5):
                 diag_proportions.append(0.0)
             else:
                 diag_proportions.append(retention)

--- a/cbm_defaults/dm_values_processor.py
+++ b/cbm_defaults/dm_values_processor.py
@@ -4,7 +4,7 @@ import itertools
 
 
 def process_dm_values(
-    rows: list, pool_cross_walk: dict[int, int]
+    rows: list, colnames: list[str], pool_cross_walk: dict[int, int]
 ) -> pd.DataFrame:
 
     # rows is a list of dicts with the following keys:
@@ -13,7 +13,10 @@ def process_dm_values(
     # tblDMValuesLookup.DMColumn,
     # tblDMValuesLookup.Proportion
 
-    aidb_dm_values = pd.DataFrame(data=rows)
+    aidb_dm_values = pd.DataFrame(
+        columns=colnames,
+        data=rows
+    )
 
     # drop DM values where the CBM-CFS3 pool cross walk maps to -1
     # this affects the following CBM-CFS3 pools that are not carried forward

--- a/cbm_defaults/dm_values_processor.py
+++ b/cbm_defaults/dm_values_processor.py
@@ -81,7 +81,11 @@ def process_dm_values(
         key = (int(combo[0]), int(combo[1]))
         if key in off_diag_rowsums_dict:
             row_sum = off_diag_rowsums_dict[key]
-            diag_proportions.append(1.0 - row_sum)
+            retention = 1.0 - row_sum
+            if np.isclose(abs(retention), 0.0, atol=1.e-6):
+                diag_proportions.append(0.0)
+            else:
+                diag_proportions.append(retention)
         else:
             diag_proportions.append(1.0)
 

--- a/cbm_defaults/dm_values_processor.py
+++ b/cbm_defaults/dm_values_processor.py
@@ -1,0 +1,136 @@
+import pandas as pd
+import numpy as np
+import itertools
+
+def process_dm_values(
+    rows: list, pool_cross_walk: dict[int, int]
+) -> pd.DataFrame:
+
+    # rows is a list of dicts with the following keys:
+    # tblDMValuesLookup.DMID,
+    # tblDMValuesLookup.DMRow,
+    # tblDMValuesLookup.DMColumn,
+    # tblDMValuesLookup.Proportion
+
+    aidb_dm_values = pd.DataFrame(data=rows)
+
+    # drop DM values where the CBM-CFS3 pool cross walk maps to -1
+    # this affects the following CBM-CFS3 pools that are not carried forward
+    # into the libcbm/cbmdefaults database:
+    #
+    #   CBM3 Pool                 CBM3 Pool ID
+    #   ________________________  ____________
+    #   Softwood Submerchantable      4
+    #   Hardwood Submerchantable     10
+    #   Black Carbon                 24
+    #   Peat                         25
+
+    aidb_dm_values["DMRow"] = aidb_dm_values["DMRow"].map(pool_cross_walk)
+    if pd.isnull(aidb_dm_values["DMRow"]).any():
+        raise ValueError("pool_cross_walk DMRow mapping failure")
+    aidb_dm_values["DMColumn"] = aidb_dm_values["DMColumn"].map(
+        pool_cross_walk
+    )
+    if pd.isnull(aidb_dm_values["DMColumn"]).any():
+        raise ValueError("pool_cross_walk DMColumn mapping failure")
+    drop_loc = (
+        (aidb_dm_values["DMRow"] == -1) |
+        (aidb_dm_values["DMColumn"] == -1)
+    )
+
+    # now compensate for a GCBM supported format that does not work in libcbm:
+    # the diagonal matrix values may be omitted in GBCM but not in libcbm
+    # the following code adds the validated diagonal values based on the
+    # off-diagonal values present in the data
+    aidb_dm_values = aidb_dm_values[~drop_loc].reset_index(drop=True)
+    unique_dmids = aidb_dm_values["DMID"].drop_duplicates()
+    all_unique_pool_ids = [
+        p_id for p_id in pool_cross_walk.values()
+        if p_id not in [-1, 22, 23, 24, 25, 26]
+        # exclude the unmapped, and emission pools so they dont
+        # appear in the diagonal to match CBM-CFS3 format
+    ]
+    dmid_pool_id_combinations = list(
+        itertools.product(unique_dmids, all_unique_pool_ids)
+    )
+
+    off_diag_rowsums = aidb_dm_values.loc[
+        aidb_dm_values["DMRow"] != aidb_dm_values["DMColumn"]
+    ][
+        ["DMID", "DMRow", "Proportion"]
+    ].groupby(
+        ["DMID", "DMRow"]
+    ).sum().reset_index()
+
+    off_diag_rowsums_dict = {
+        (int(row["DMID"]), int(row["DMRow"])): float(row["Proportion"])
+        for _, row in off_diag_rowsums.iterrows()
+    }
+
+    diag_proportions: list[float] = []
+    diag_dmids: list[int] = []
+    diag_dmrow_dmcol: list[int] = []
+    for combo in dmid_pool_id_combinations:
+        diag_dmids.append(int(combo[0]))
+        diag_dmrow_dmcol.append(int(combo[1]))
+        key = (int(combo[0]), int(combo[1]))
+        if key in off_diag_rowsums_dict:
+            row_sum = off_diag_rowsums_dict[key]
+            diag_proportions.append(1.0 - row_sum)
+        else:
+            diag_proportions.append(1.0)
+
+    diag_dm_values = pd.DataFrame(
+        columns=["DMID", "DMRow", "DMColumn", "Proportion"],
+        data={
+            "DMID": diag_dmids,
+            "DMRow": diag_dmrow_dmcol,
+            "DMColumn": diag_dmrow_dmcol,
+            "Proportion": diag_proportions
+        }
+    )
+
+    # merge onto the source data:
+    dm_value_merged = aidb_dm_values.merge(
+        diag_dm_values,
+        left_on=["DMID", "DMRow", "DMColumn"],
+        right_on=["DMID", "DMRow", "DMColumn"],
+        how="outer",
+        suffixes=("_cbm3", "_diag")
+    )
+
+    output_dm_values = pd.DataFrame(
+        data={
+            "DMID": np.where(
+                pd.isnull(dm_value_merged["DMID_cbm3"]),
+                dm_value_merged["DMID_diag"],
+                dm_value_merged["DMID_cbm3"]
+            ),
+            "DMRow": np.where(
+                pd.isnull(dm_value_merged["DMRow_cbm3"]),
+                dm_value_merged["DMRow_diag"],
+                dm_value_merged["DMRow_cbm3"]
+            ),
+            "DMColumn": np.where(
+                pd.isnull(dm_value_merged["DMColumn_cbm3"]),
+                dm_value_merged["DMColumn_diag"],
+                dm_value_merged["DMColumn_cbm3"]
+            ),
+            "Proportion": np.where(
+                pd.isnull(dm_value_merged["Proportion_cbm3"]),
+                dm_value_merged["Proportion_diag"],
+                dm_value_merged["Proportion_cbm3"]
+            )
+        }
+    )
+
+    # qaqc check:
+    rowsums = output_dm_values[
+        ["DMID", "DMRow", "Proportion"]
+    ].groupby(
+        ["DMID", "DMRow"]
+    ).sum()["Proportion"]
+    if not np.allclose(rowsums, 1.0):
+        raise ValueError("rowsums not close to 1.0")
+
+    return output_dm_values.sort_values(by=["DMID", "DMRow", "DMColumn"])

--- a/cbm_defaults/dm_values_processor.py
+++ b/cbm_defaults/dm_values_processor.py
@@ -134,7 +134,7 @@ def process_dm_values(
         .groupby(["DMID", "DMRow"])
         .sum()["Proportion"]
     )
-    if not np.allclose(rowsums, 1.0):
+    if not np.allclose(rowsums, 1.0, rtol=1e-3, atol=1.e-3):
         raise ValueError("rowsums not close to 1.0")
 
     return output_dm_values.sort_values(

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="cbm_defaults",
-    version="2.1.1",
+    version="2.2.0",
     description="CBM-CFS3 archive-index database to sqlite utility",
     keywords=["cbm-cfs3"],
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="cbm_defaults",
-    version="2.2.1",
+    version="2.2.2",
     description="CBM-CFS3 archive-index database to sqlite utility",
     keywords=["cbm-cfs3"],
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="cbm_defaults",
-    version="2.2.2",
+    version="2.2.3",
     description="CBM-CFS3 archive-index database to sqlite utility",
     keywords=["cbm-cfs3"],
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="cbm_defaults",
-    version="2.2.0",
+    version="2.2.1",
     description="CBM-CFS3 archive-index database to sqlite utility",
     keywords=["cbm-cfs3"],
     long_description=long_description,

--- a/test/dm_values_processor_test.py
+++ b/test/dm_values_processor_test.py
@@ -1,13 +1,118 @@
 import pandas as pd
 from cbm_defaults import dm_values_processor
+from cbm_defaults import local_csv_table
 
 
 def test_dm_values_processor():
-
+    pool_cross_walk: dict[int, int] = {}
+    for row in local_csv_table.read_csv_file("pool_cross_walk.csv"):
+        pool_cross_walk[int(row["cbm3_pool_code"])] = int(
+            row["cbm3_5_pool_code"]
+        )
     input = pd.DataFrame(
         columns=["DMID", "DMRow", "DMColumn", "Proportion"],
-        data = [
-            []
+        data=[
+            [506, 12, 14, 0.25],
+            [506, 11, 16, 0.25],
+            [506, 10, 23, 0.25],
+            [506, 9, 23, 0.25],
+            [506, 8, 13, 0.25],
+            [506, 7, 22, 0.25],
+            [506, 6, 14, 0.25],
+            [506, 5, 16, 0.25],
+            [506, 4, 21, 0.25],
+            [506, 3, 21, 0.25],
+            [506, 2, 13, 0.25],
+            [506, 1, 20, 0.25],
+            [10, 1, 20, 1],
+            [10, 2, 13, 0.9],
+            [10, 2, 26, 0.1],
+            [10, 3, 21, 1],
+            [10, 4, 21, 1],
+            [10, 5, 15, 0.5],
+            [10, 5, 16, 0.5],
+            [10, 6, 13, 0.5],
+            [10, 6, 14, 0.5],
+            [10, 7, 22, 1],
+            [10, 8, 13, 0.9],
+            [10, 8, 26, 0.1],
+            [10, 9, 23, 1],
+            [10, 10, 23, 1],
+            [10, 11, 15, 0.5],
+            [10, 11, 16, 0.5],
+            [10, 12, 13, 0.5],
+            [10, 12, 14, 0.5],
+            [10, 13, 13, 1],
+            [10, 14, 14, 1],
+            [10, 15, 15, 1],
+            [10, 16, 16, 1],
+            [10, 17, 17, 1],
+            [10, 18, 18, 1],
+            [10, 19, 19, 1],
+            [10, 20, 20, 1],
+            [10, 21, 21, 1],
+            [10, 22, 22, 1],
+            [10, 23, 23, 1],
+            [10, 24, 24, 1],
+            [10, 25, 25, 1],
+        ]
+
+    )
+
+    missing_expected_506_values = pd.DataFrame(
+        columns=["DMID", "DMRow", "DMColumn", "Proportion"],
+        data=[
+            [506, 12, 12, 0.75],
+            [506, 11, 11, 0.75],
+            [506, 10, 10, 0.75],
+            [506, 9, 9, 0.75],
+            [506, 8, 8, 0.75],
+            [506, 7, 7, 0.75],
+            [506, 6, 6, 0.75],
+            [506, 5, 5, 0.75],
+            [506, 4, 4, 0.75],
+            [506, 3, 3, 0.75],
+            [506, 2, 2, 0.75],
+            [506, 1, 1, 0.75],
+            [506, 13, 13, 1.0],
+            [506, 14, 14, 1.0],
+            [506, 15, 15, 1.0],
+            [506, 16, 16, 1.0],
+            [506, 17, 17, 1.0],
+            [506, 18, 18, 1.0],
+            [506, 19, 19, 1.0],
+            [506, 20, 20, 1.0],
+            [506, 21, 21, 1.0],
+            [506, 22, 22, 1.0],
+            [506, 23, 23, 1.0],
+            [506, 24, 24, 1.0],
+            [506, 25, 25, 1.0],
         ]
     )
-    dm_values_processor.process_dm_values()
+    expected_result = pd.concat([
+        input, missing_expected_506_values
+    ])
+
+    expected_result["DMRow"] = expected_result["DMRow"].map(
+        pool_cross_walk
+    )
+    expected_result["DMColumn"] = expected_result["DMColumn"].map(
+        pool_cross_walk
+    )
+    expected_result = expected_result.loc[
+        (
+            (expected_result["DMRow"] > 0)
+            & (expected_result["DMColumn"] > 0)
+        )
+    ]
+
+    result = dm_values_processor.process_dm_values(
+        input.to_dict("records"), pool_cross_walk
+    )
+
+    pd.testing.assert_frame_equal(
+        expected_result.sort_values(
+            by=["DMID", "DMRow", "DMColumn"]
+        ).reset_index(drop=True),
+        result
+    )

--- a/test/dm_values_processor_test.py
+++ b/test/dm_values_processor_test.py
@@ -1,0 +1,13 @@
+import pandas as pd
+from cbm_defaults import dm_values_processor
+
+
+def test_dm_values_processor():
+
+    input = pd.DataFrame(
+        columns=["DMID", "DMRow", "DMColumn", "Proportion"],
+        data = [
+            []
+        ]
+    )
+    dm_values_processor.process_dm_values()

--- a/test/dm_values_processor_test.py
+++ b/test/dm_values_processor_test.py
@@ -107,7 +107,9 @@ def test_dm_values_processor():
     ]
 
     result = dm_values_processor.process_dm_values(
-        input.to_dict("records"), pool_cross_walk
+        input.to_dict("records"),
+        ["DMID", "DMRow", "DMColumn", "Proportion"],
+        pool_cross_walk
     )
 
     pd.testing.assert_frame_equal(

--- a/test/dm_values_processor_test.py
+++ b/test/dm_values_processor_test.py
@@ -144,11 +144,11 @@ def test_dm_values_processor_zero_retentions():
             # the 3, 21 and 3, 20 pool flows sum to < 1.0 resulting in a
             # slightly positive retention,
             [506, 3, 21, 0.25],
-            [506, 3, 20, 0.7499999],
+            [506, 3, 20, 0.749999],
             # the 2,13 and 2,14 pool flows sum to > 1.0 resulting in a
             # slightly negative retention.
             [506, 2, 13, 0.25],
-            [506, 2, 14, 0.7500001],
+            [506, 2, 14, 0.750001],
             [506, 1, 20, 0.25],
             [506, 1, 21, 0.75],
             [10, 1, 20, 1],

--- a/test/dm_values_processor_test.py
+++ b/test/dm_values_processor_test.py
@@ -118,3 +118,127 @@ def test_dm_values_processor():
         ).reset_index(drop=True),
         result
     )
+
+
+def test_dm_values_processor_zero_retentions():
+
+    # check that when the retention is zero, or close to zero, the the output
+    # retention is exactly zero
+    pool_cross_walk: dict[int, int] = {}
+    for row in local_csv_table.read_csv_file("pool_cross_walk.csv"):
+        pool_cross_walk[int(row["cbm3_pool_code"])] = int(
+            row["cbm3_5_pool_code"]
+        )
+    input = pd.DataFrame(
+        columns=["DMID", "DMRow", "DMColumn", "Proportion"],
+        data=[
+            [506, 12, 14, 0.25],
+            [506, 11, 16, 0.25],
+            [506, 10, 23, 0.25],
+            [506, 9, 23, 0.25],
+            [506, 8, 13, 0.25],
+            [506, 7, 22, 0.25],
+            [506, 6, 14, 0.25],
+            [506, 5, 16, 0.25],
+            [506, 4, 21, 0.25],
+            # the 3, 21 and 3, 20 pool flows sum to < 1.0 resulting in a
+            # slightly positive retention,
+            [506, 3, 21, 0.25],
+            [506, 3, 20, 0.7499999],
+            # the 2,13 and 2,14 pool flows sum to > 1.0 resulting in a
+            # slightly negative retention.
+            [506, 2, 13, 0.25],
+            [506, 2, 14, 0.7500001],
+            [506, 1, 20, 0.25],
+            [506, 1, 21, 0.75],
+            [10, 1, 20, 1],
+            [10, 2, 13, 0.9],
+            [10, 2, 26, 0.1],
+            [10, 3, 21, 1],
+            [10, 4, 21, 1],
+            [10, 5, 15, 0.5],
+            [10, 5, 16, 0.5],
+            [10, 6, 13, 0.5],
+            [10, 6, 14, 0.5],
+            [10, 7, 22, 1],
+            [10, 8, 13, 0.9],
+            [10, 8, 26, 0.1],
+            [10, 9, 23, 1],
+            [10, 10, 23, 1],
+            [10, 11, 15, 0.5],
+            [10, 11, 16, 0.5],
+            [10, 12, 13, 0.5],
+            [10, 12, 14, 0.5],
+            [10, 13, 13, 1],
+            [10, 14, 14, 1],
+            [10, 15, 15, 1],
+            [10, 16, 16, 1],
+            [10, 17, 17, 1],
+            [10, 18, 18, 1],
+            [10, 19, 19, 1],
+            [10, 20, 20, 1],
+            [10, 21, 21, 1],
+            [10, 22, 22, 1],
+            [10, 23, 23, 1],
+            [10, 24, 24, 1],
+            [10, 25, 25, 1],
+        ]
+
+    )
+
+    missing_expected_506_values = pd.DataFrame(
+        columns=["DMID", "DMRow", "DMColumn", "Proportion"],
+        data=[
+            [506, 12, 12, 0.75],
+            [506, 11, 11, 0.75],
+            [506, 10, 10, 0.75],
+            [506, 9, 9, 0.75],
+            [506, 8, 8, 0.75],
+            [506, 7, 7, 0.75],
+            [506, 6, 6, 0.75],
+            [506, 5, 5, 0.75],
+            [506, 4, 4, 0.75],
+            [506, 13, 13, 1.0],
+            [506, 14, 14, 1.0],
+            [506, 15, 15, 1.0],
+            [506, 16, 16, 1.0],
+            [506, 17, 17, 1.0],
+            [506, 18, 18, 1.0],
+            [506, 19, 19, 1.0],
+            [506, 20, 20, 1.0],
+            [506, 21, 21, 1.0],
+            [506, 22, 22, 1.0],
+            [506, 23, 23, 1.0],
+            [506, 24, 24, 1.0],
+            [506, 25, 25, 1.0],
+        ]
+    )
+    expected_result = pd.concat([
+        input, missing_expected_506_values
+    ])
+
+    expected_result["DMRow"] = expected_result["DMRow"].map(
+        pool_cross_walk
+    )
+    expected_result["DMColumn"] = expected_result["DMColumn"].map(
+        pool_cross_walk
+    )
+    expected_result = expected_result.loc[
+        (
+            (expected_result["DMRow"] > 0)
+            & (expected_result["DMColumn"] > 0)
+        )
+    ]
+
+    result = dm_values_processor.process_dm_values(
+        input.to_dict("records"),
+        ["DMID", "DMRow", "DMColumn", "Proportion"],
+        pool_cross_walk
+    )
+
+    pd.testing.assert_frame_equal(
+        expected_result.sort_values(
+            by=["DMID", "DMRow", "DMColumn"]
+        ).reset_index(drop=True),
+        result
+    )


### PR DESCRIPTION
* add support for special dm value table format allowed and used by GCBM: the diagonal matrix values may be omitted in GBCM but not in libcbm 
* the new module computes the diagonal values
* the new module performs qaqc at process time (rowsums close to 1.0 etc)
* add unit tests for above change

